### PR TITLE
Perlcritic test fix

### DIFF
--- a/lib/st/api/lims/warehouse.pm
+++ b/lib/st/api/lims/warehouse.pm
@@ -31,7 +31,7 @@ subtype __PACKAGE__.'::EAN13digits'
 
 subtype __PACKAGE__.'::EAN13'
   => where { ##no critic ( ValuesAndExpressions::ProhibitMagicNumbers)
-             my@a=split //sm, $_;
+             my@a=split //sm;
              my$chk=pop @a;
              my$sum=0; my$odd=0;
              while(@a){my$v=pop@a; $sum+= (($odd^=1) ? 3 : 1) * $v; }

--- a/t/40-st_api_lims_warehouse.t
+++ b/t/40-st_api_lims_warehouse.t
@@ -3,7 +3,7 @@
 # Created:       16 July 2013
 use strict;
 use warnings;
-use Test::More tests => 39;
+use Test::More tests => 38;
 use Test::Exception;
 use t::npg_warehouse::util;
 
@@ -71,10 +71,8 @@ ok($lims->study_contains_nonconsented_human, 'nonconsented human is present');
 is($lims->purpose,'qc','purpose');
 
 throws_ok{ st::api::lims::warehouse->new(@ws,tube_ean13_barcode => '3980331130774') } qr/checksum fail/, 'EAN13 checksum fail'; 
-dies_ok  { st::api::lims::warehouse->new(@ws,tube_ean13_barcode => '980331130778') } 'expect 13 characters for EAN13';
-TODO: { local $TODO = 'Fix error reported for too few character in EAN13'; # then replace above dies_ok with throws_ok below
-  throws_ok{ st::api::lims::warehouse->new(@ws,tube_ean13_barcode => '980331130774') } qr/should be 13 digits/, 'expect 13 characters for EAN13';
-}
+throws_ok{ st::api::lims::warehouse->new(@ws,tube_ean13_barcode => '980331130774') }
+  qr/EAN13 barcode checksum fail for code 980331130774/, 'expect 13 characters for EAN13';
 lives_and { is st::api::lims::warehouse->new(@ws,tube_ean13_barcode => '0280331130779')->tube_barcode, '331130' } 'EAN13 barcode can start with 0';
 
 1;


### PR DESCRIPTION
Test failure when running deployment test under Jenkins

   Failed test 'Test::Perl::Critic for "lib/st/api/lims/warehouse.pm"'
at t/00-critic.t line 49.
Useless use of $_ at lib/st/api/lims/warehouse.pm line 34, policy BuiltinFunctions::ProhibitUselessTopic